### PR TITLE
Fix misspell path

### DIFF
--- a/.github/actions/misspell/action.yml
+++ b/.github/actions/misspell/action.yml
@@ -16,14 +16,14 @@ runs:
           export MISSPELL_VERSION="v0.6.0"
           curl -sfL https://raw.githubusercontent.com/golangci/misspell/master/install-misspell.sh | sh -s -- -b ./bin ${MISSPELL_VERSION}
           echo "## misspell $MISSPELL_VERSION" >> $GITHUB_STEP_SUMMARY
-          "$HOME/go/bin/misspell" -v
+          ./bin/misspell -v
     - name: Run misspell
       shell: bash
       run: |
           if [ -n "${{ inputs.EXCEPTIONS }}" ]; then
-              "$HOME/go/bin/misspell" --error -i ${{ inputs.EXCEPTIONS }} . >misspell.log
+              ./bin/misspell --error -i ${{ inputs.EXCEPTIONS }} . >misspell.log
           else
-              "$HOME/go/bin/misspell" --error . >misspell.log
+              ./bin/misspell --error . >misspell.log
           fi
     - name: Show misspell.log
       if: always()


### PR DESCRIPTION
It gets downloaded ./bin/misspell.

## Changelog
- [x] Changelog update not applicable (CI changes only for example)
**or**
- [ ] Changelog updated

### For new features
- [x] Not applicable
**or**
- [ ] Documentation covers inputs/arguments
- [ ] Documentation has clear description of the action/workflow
- [ ] Documentation has an example how to use the action/workflow
